### PR TITLE
Extract figures from HTML output

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,16 @@ For example:
 
     nbcollection convert my_notebooks --template-file=templates/custom.tpl
 
+#### Extracting figures and other preprocessors
+
+You can enable additional
+[preprocessors](https://nbconvert.readthedocs.io/en/latest/api/preprocessors.html#specialized-preprocessors)
+for the HTML exporter by passing one or more preprocessor names to the
+`--preprocessors` option. A useful preprocessor is `ExtractOutputPreprocessor`,
+which extracts figures from the HTML into separate files for better page loading
+performance:
+
+    nbcollection convert my_notebooks --preprocessors=nbconvert.preprocessors.ExtractOutputPreprocessor
 
 #### Only execute the notebooks
 

--- a/nbcollection/commands/convert.py
+++ b/nbcollection/commands/convert.py
@@ -22,6 +22,10 @@ def convert(args=None):
                         help="Controls whether to make an index page that "
                              "lists all of the converted notebooks.")
 
+    parser.add_argument('--preprocessors', nargs='*', default=[],
+                        help="Preprocessors for convert. For example, "
+                             "nbconvert.preprocessors.ExtractOutputPreprocessor.")
+
     for trait_name in convert_trait_names:
         trait = getattr(HTMLExporter, trait_name)
         parser.add_argument("--" + trait_name.replace('_', '-'),

--- a/nbcollection/converter.py
+++ b/nbcollection/converter.py
@@ -45,7 +45,8 @@ class nbcollectionConverter:
     def __init__(self, notebooks, overwrite=False,
                  build_path=None, flatten=False,
                  exclude_pattern=None, include_pattern=None,
-                 execute_kwargs=None, convert_kwargs=None, **kwargs):
+                 execute_kwargs=None, convert_kwargs=None,
+                 convert_preprocessors=None, **kwargs):
         """
         Parameters
         ----------
@@ -109,7 +110,8 @@ class nbcollectionConverter:
                                     flatten=flatten),
                                 overwrite=overwrite,
                                 execute_kwargs=execute_kwargs,
-                                convert_kwargs=convert_kwargs)
+                                convert_kwargs=convert_kwargs,
+                                convert_preprocessors=convert_preprocessors)
                             nbs.append(nb)
 
             elif os.path.isfile(notebook):

--- a/nbcollection/notebook.py
+++ b/nbcollection/notebook.py
@@ -6,6 +6,7 @@ import time
 from nbconvert.preprocessors import ExecutePreprocessor, CellExecutionError
 from nbconvert.exporters import HTMLExporter
 from nbconvert.writers import FilesWriter
+from traitlets.config import Config
 import nbformat
 
 # Package
@@ -68,6 +69,11 @@ class nbcollectionNotebook:
         if convert_kwargs is None:
             convert_kwargs = dict()
         self.convert_kwargs = convert_kwargs
+
+        self.converter_config = Config()
+        self.converter_config.HTMLExporter.preprocessors = [
+            'nbconvert.preprocessors.ExtractOutputPreprocessor'
+        ]
 
     def execute(self):
         """Execute this notebook file and write out the executed contents to a
@@ -142,7 +148,8 @@ class nbcollectionNotebook:
 
         # Exports the notebook to HTML
         logger.debug('Exporting notebook to HTML...')
-        exporter = HTMLExporter(**self.convert_kwargs)
+        exporter = HTMLExporter(config=self.converter_config,
+                                **self.convert_kwargs)
         output, resources = exporter.from_filename(self.exec_path,
                                                    resources=resources)
 

--- a/nbcollection/notebook.py
+++ b/nbcollection/notebook.py
@@ -20,7 +20,8 @@ class nbcollectionNotebook:
     nbformat_version = 4
 
     def __init__(self, file_path, output_path=None, overwrite=False,
-                 execute_kwargs=None, convert_kwargs=None):
+                 execute_kwargs=None, convert_kwargs=None,
+                 convert_preprocessors=None):
         """
         Parameters
         ----------
@@ -35,6 +36,9 @@ class nbcollectionNotebook:
             ``nbconvert.ExecutePreprocessor``.
         convert_kwargs : dict (optional)
             Keyword arguments passed through to ``nbconvert.HTMLExporter``.
+        convert_preprocessors : list of str (optional)
+            The preprocessors enabled for the HTMLExporter. For example,
+            ``"nbconvert.preprocessors.ExtractOutputPreprocessor"``.
         """
 
         if not os.path.exists(file_path):
@@ -71,9 +75,8 @@ class nbcollectionNotebook:
         self.convert_kwargs = convert_kwargs
 
         self.converter_config = Config()
-        self.converter_config.HTMLExporter.preprocessors = [
-            'nbconvert.preprocessors.ExtractOutputPreprocessor'
-        ]
+        if convert_preprocessors is not None:
+            self.converter_config.HTMLExporter.preprocessors = convert_preprocessors
 
     def execute(self):
         """Execute this notebook file and write out the executed contents to a


### PR DESCRIPTION
The default behavior of the HTMLExporter is to embed figures in the HTML. This has a few downsides for performance, but the biggest issue is Astropy Librarian can't reference these figures to include in the search
front end (an alternative approach would be to prepare special thumbnails for the homepage; which is something we should do regardless eventually).

This adds the ExtractOutputPreprocessor to the HTMLExporter configuration. It's hard-coded at the moment. I did try looking at how this might be added through the existing trait-based CLI parsing and it wasn't clear to me how to support a list-based trait.

This is based on the tutorial:
https://nbconvert.readthedocs.io/en/latest/nbconvert_library.html#Extracting-Figures-using-the-HTML-Exporter